### PR TITLE
fix(renovate): include v prefix in host-spawn version capture

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,10 +33,9 @@
         "/\\/co\\.anysphere\\.cursor\\.yaml$/"
       ],
       "matchStrings": [
-        "url: https://github\\.com/(?<depName>1player/host-spawn)/releases/download/v(?<currentValue>[\\d.]+)/host-spawn-\\w+\\s+sha256: (?<currentDigest>[a-f0-9]+)"
+        "url: https://github\\.com/(?<depName>1player/host-spawn)/releases/download/(?<currentValue>v[\\d.]+)/host-spawn-\\w+\\s+sha256: (?<currentDigest>[a-f0-9]+)"
       ],
-      "datasourceTemplate": "github-release-attachments",
-      "extractVersionTemplate": "^v(?<version>.+)$"
+      "datasourceTemplate": "github-release-attachments"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary
- Renovate was getting a 404 when looking up `1player/host-spawn` releases because `extractVersionTemplate` stripped the `v` prefix, causing it to query `/releases/tags/1.6.2` instead of `/releases/tags/v1.6.2`
- Fix by capturing the `v` prefix directly in `currentValue` and removing the now-unnecessary `extractVersionTemplate`

## Test plan
- [x] Ran Renovate locally in dry-run mode — no `lookupUpdates error` for host-spawn
- [x] Verified `1player/host-spawn` extraction and release lookup succeeds